### PR TITLE
Don't execute default step when help is invoked

### DIFF
--- a/build/dotnet-steps.nuspec
+++ b/build/dotnet-steps.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>dotnet-steps</id>
     <title>dotnet-steps</title>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <description>A small step for man kind, but a HUGE leap for build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>

--- a/src/steps.csx
+++ b/src/steps.csx
@@ -125,6 +125,12 @@ private static class StepRunner
 
         var stepDelegates = GetStepDelegates();
 
+        if (stepNames.Contains("help", StringComparer.OrdinalIgnoreCase))
+        {
+            ShowHelp(stepDelegates.Values.ToArray());
+            return;
+        }
+
         if (stepDelegates.Keys.Intersect(stepNames).Count() == 0)
         {
             await GetDefaultDelegate(stepDelegates)();
@@ -134,11 +140,11 @@ private static class StepRunner
         {
             _callStack.Clear();
 
-            if (stepName.Equals("help", StringComparison.OrdinalIgnoreCase))
-            {
-                stepDelegates.Values.ToArray().ShowHelp();
-                continue;
-            }
+            // if (stepName.Equals("help", StringComparison.OrdinalIgnoreCase))
+            // {
+            //     stepDelegates.Values.ToArray().ShowHelp();
+            //     break;
+            // }
 
             if (stepDelegates.TryGetValue(stepName, out var stepDelegate))
             {

--- a/src/steps.tests.csx
+++ b/src/steps.tests.csx
@@ -44,6 +44,7 @@ public async Task ShouldShowHelp()
     TestContext.StandardOut.Should().Contain("Available Steps");
     TestContext.StandardOut.Should().Contain("This is step one");
     TestContext.StandardOut.Should().Contain("step1 (default)");
+    TestContext.StandardOut.Should().NotContain("Steps Summary");
 }
 
 public async Task ShouldReportNestedStep()


### PR DESCRIPTION
Fixes a bug that caused he default step to be invoked when executing with the `help` step.